### PR TITLE
Add support for requiring 'n' approvers when merging a pull-request

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,3 +1,2 @@
 * Support an arbitrary number of rules (AUI Tab element?)
-* Add mechanism to require approval from only 'n' approvers in list
 * i18n support

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>au.com.fami</groupId>
     <artifactId>approve_check_hook</artifactId>
-    <version>1.0</version>
+    <version>1.1</version>
 
     <name>Approve Checker</name>
     <description>This plugin prevents pull requests from being merged to certain branches until they are approved by a specific list of users.</description>

--- a/src/main/java/au/com/fami/approve_check_hook/FormValidator.java
+++ b/src/main/java/au/com/fami/approve_check_hook/FormValidator.java
@@ -45,6 +45,7 @@ public class FormValidator implements RepositorySettingsValidator {
         String field_enable = "enable" + num;
         String field_branch = "branch" + num;
         String field_approvers = "approvers" + num;
+        String field_minCount = "min" + num;
 
         Boolean enabled = settings.getBoolean(field_enable);
         if(enabled == null) return;
@@ -76,6 +77,16 @@ public class FormValidator implements RepositorySettingsValidator {
             }
         } else {
             errors.addFieldError(field_approvers, "Error: No approvers specified");
+        }
+
+        int approverCount = settings.getInt(field_minCount, 0);
+        if (approverCount < 0) {
+            errors.addFieldError(field_minCount,
+                    "Error: At least one approver should be required (or 0 for all)");
+        } else if (approvers != null
+                && approverCount > approvers.split(",").length) {
+            errors.addFieldError(field_minCount,
+                    "Error: Cannot have a count higher than the number of approvers specified");
         }
     }
 }

--- a/src/main/resources/static/approve-checker.soy
+++ b/src/main/resources/static/approve-checker.soy
@@ -29,6 +29,13 @@
             {param descriptionText: 'Comma-separated list of people who must give approval for changes to be merged into the specified branch' /}
             {param errorTexts:      $errors ? $errors['approvers' + $num] : null /}
         {/call}
+        {call aui.form.textField}
+            {param id:              'min' + $num /}
+            {param value:           $config['min' + $num] /}
+            {param labelContent:    'Minimum Number of Approvers' /}
+            {param descriptionText: 'Select the minimum number of approvers, or 0 to require all' /}
+            {param errorTexts:      $errors ? $errors['min' + $num] : null /}
+        {/call}
     </div>
 {/template}
 


### PR DESCRIPTION
I added a configuration to allow specifying the minimum number fo approvers in the provided list. The change should be backwards compatible as it defaults to requiring the entire list. I tested and confirmed that it works for me using Stash 3.3.1
