### PR TITLE
[#7] Allow to exclude service users from approve checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>au.com.fami</groupId>
     <artifactId>approve_check_hook</artifactId>
-    <version>1.1</version>
+    <version>1.2-SNAPSHOT</version>
 
     <name>Approve Checker</name>
     <description>This plugin prevents pull requests from being merged to certain branches until they are approved by a specific list of users.</description>
@@ -44,7 +44,6 @@
         <dependency>
             <groupId>com.atlassian.stash</groupId>
             <artifactId>stash-spi</artifactId>
-            <version>${stash.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -3,7 +3,6 @@
         <description>${project.description}</description>
         <vendor name="Daniel Burr" url="https://github.com/dgburr" />
         <version>${project.version}</version>
-        <!-- <param name="plugin-icon">images/plugin-icon.png</param> -->
         <param name="plugin-logo">images/icon.png</param>
     </plugin-info>
 
@@ -28,5 +27,6 @@
     <component-import key="soyTemplateRenderer" interface="com.atlassian.soy.renderer.SoyTemplateRenderer" />
     <component-import key="repositoryMetadataService" interface="com.atlassian.stash.repository.RepositoryMetadataService" />
     <component-import key="userService" interface="com.atlassian.stash.user.UserService" />
+    <component-import key="stashAuthenticationContext" interface="com.atlassian.stash.user.StashAuthenticationContext" />
    
 </atlassian-plugin>

--- a/src/main/resources/static/approve-checker.js
+++ b/src/main/resources/static/approve-checker.js
@@ -4,14 +4,19 @@ AJS.toInit(function() {
             $(document.body).on('change', '#enable' + num, function(event) {
                 // show/hide container based on state of checkbox
                 var container = $("#rule" + num + "-container");
-                if(event.currentTarget.checked == true) container.show();
-                else container.hide();
+                if(event.currentTarget.checked == true) {
+                  container.show();
+                } else {
+                  container.hide();
+                }
                 // update height of dialog
                 var dialog = $("#repository-hook-dialog").data("dialog_obj");
-                if(!(typeof dialog === 'undefined')) dialog.updateHeight();
+                if(!(typeof dialog === 'undefined')) {
+                  dialog.updateHeight();
+                }
             });
         }
 
-        for(i = 1; i < 6; i++) register_callback(i);
+        for(i = 1; i <= 5; i++) register_callback(i);
     })(AJS.$);
 });

--- a/src/main/resources/static/approve-checker.soy
+++ b/src/main/resources/static/approve-checker.soy
@@ -37,6 +37,15 @@
             {param extraClasses:    'long' /}
             {param errorTexts:      $errors ? $errors['min' + $num] : null /}
         {/call}
+        {call aui.form.checkboxField}
+            {param legendContent:   'Allow Service User' /}
+            {param fields: [[
+              'id':                 'allowServiceUser' + $num,
+              'isChecked':          $config['allowServiceUser' + $num],
+              'labelText':          'Enabled'
+            ]] /} 
+            {param descriptionText: 'Always allow service users with access keys (e.g. CI Server) to push, despite of missing approvers.' /}
+        {/call}
     </div>
 {/template}
 


### PR DESCRIPTION
Hi

This change allows that service users (users that only have a ssh key registered in the 'access key' settings but are not "real" stash users) can commit even though not everyone approved.
This is very useful in environments where e.g. the CI server does releases or tagging and therefore needs to be able to push. Note that this has only an effect if it is enabled, which it is not by default.

I tested this locally as follows:
- Run the plugin with 'atlas-run'
- Login to stash and register my ssh key for the test project and enable the approve check plugin without enableing the "allow service user" feature.
- Try to push a change to the repo (connected by ssh using the registered ssh key) -> Should be declined
- Enable "allow service user" in stash
- Try to push again -> Should now work!

See here for an example from the GUI:
![image](https://cloud.githubusercontent.com/assets/974833/7863559/5b96614a-055d-11e5-8e62-92fe5119a08b.png)

Thank you for merging.
